### PR TITLE
Handle parse errors

### DIFF
--- a/utils/validate/validate-schemas.ts
+++ b/utils/validate/validate-schemas.ts
@@ -80,26 +80,30 @@ function validateCollection(filepath: string) {
   }
 }
 
-function printIssues(error: ZodError, recursion: number = 0) {
-  for (let issue of error.issues) {
-    if (issue.code == "invalid_type") {
-      let log = `${issue.path.join(".")}:  ${issue.message}`;
-      console.log(`${"- ".repeat(recursion)}${log}`);
-    } else if (issue.code == "invalid_union") {
-      let log = `${issue.path.join(".")}:  ${issue.message}:`;
-      console.log(`${"- ".repeat(recursion)}${log}`);
-      for (let unionError of issue.unionErrors) {
-        printIssues(unionError, recursion + 1);
+function printIssues(error: Error, recursion: number = 0) {
+  if error instanceof ZodError {
+    for (let issue of error.issues) {
+      if (issue.code == "invalid_type") {
+        let log = `${issue.path.join(".")}:  ${issue.message}`;
+        console.log(`${"- ".repeat(recursion)}${log}`);
+      } else if (issue.code == "invalid_union") {
+        let log = `${issue.path.join(".")}:  ${issue.message}:`;
+        console.log(`${"- ".repeat(recursion)}${log}`);
+        for (let unionError of issue.unionErrors) {
+          printIssues(unionError, recursion + 1);
+        }
+      } else if (issue.code == "invalid_literal") {
+        let log = `${issue.path.join(".")}:  not ${issue.expected}`;
+        console.log(`${"- ".repeat(recursion)}${log}`);
+      } else if (issue.code == "unrecognized_keys") {
+        let log = `${issue.message}`;
+        console.log(`${"- ".repeat(recursion)}${log}`);
+      } else {
+        console.log(issue);
       }
-    } else if (issue.code == "invalid_literal") {
-      let log = `${issue.path.join(".")}:  not ${issue.expected}`;
-      console.log(`${"- ".repeat(recursion)}${log}`);
-    } else if (issue.code == "unrecognized_keys") {
-      let log = `${issue.message}`;
-      console.log(`${"- ".repeat(recursion)}${log}`);
-    } else {
-      console.log(issue);
     }
+  } else {
+    console.log(e.stack);
   }
 }
 

--- a/utils/validate/validate-schemas.ts
+++ b/utils/validate/validate-schemas.ts
@@ -81,7 +81,7 @@ function validateCollection(filepath: string) {
 }
 
 function printIssues(error: Error, recursion: number = 0) {
-  if error instanceof ZodError {
+  if (error instanceof ZodError) {
     for (let issue of error.issues) {
       if (issue.code == "invalid_type") {
         let log = `${issue.path.join(".")}:  ${issue.message}`;

--- a/utils/validate/validate-schemas.ts
+++ b/utils/validate/validate-schemas.ts
@@ -103,7 +103,7 @@ function printIssues(error: Error, recursion: number = 0) {
       }
     }
   } else {
-    console.log(e.stack);
+    console.log(error.stack);
   }
 }
 


### PR DESCRIPTION
This fixes `printIssues` assuming that every `Error` it receives is a `ZodError`, leading it to error out and not parse any upcoming files. This is mostly relevant when the YAML frontmatter is malformed (e.g. a string starts with a quote).

(~~Note: I do not speak JavaScript, so this might be horribly broken itself!~~ I tested it in #64 and it seems fine.)