### PR TITLE
Translation sources

### DIFF
--- a/plaintext/2009/unknown-month/kulupu-mama-jine.md
+++ b/plaintext/2009/unknown-month/kulupu-mama-jine.md
@@ -15,7 +15,7 @@ tags:
   - translation
   - artwork
 original:
-  title: null
+  title: Interview With Heene Family
   authors:
     - Wolf Blitzer  # jan Muwawa
     - Richard Heene # jan Wiko Jine

--- a/plaintext/2011/07/o-pana-wawa-e-kiwen.md
+++ b/plaintext/2011/07/o-pana-wawa-e-kiwen.md
@@ -8,9 +8,9 @@ date: 2011-06-15
 date-precision: day
 tags: null
 original:
-  title: null
+  title: John
   authors:
-    - unknown # added automatically during reschema
+    - authors of the Bible
 license: null
 sources:
   - https://olukin.blogspot.com/2011/07/o-pana-wawa-e-kiwen.html

--- a/plaintext/2019/12/kasi-ike-mute.md
+++ b/plaintext/2019/12/kasi-ike-mute.md
@@ -11,7 +11,7 @@ date-precision: day
 tags:
   - music
 original:
-  title: null
+  title: 99 Bottles of Beer
   authors: null
 license: null
 sources:

--- a/plaintext/2020/07/sitelen-suwi.md
+++ b/plaintext/2020/07/sitelen-suwi.md
@@ -1,15 +1,16 @@
 ---
 title: sitelen suwi
-# original-title: Unclear to proofreader
 description: null
 authors:
   - jan Kaja
-proofreaders: null
+proofreaders:
+  - jan Tepan
+  - jan Kipo
 date: 2020-07-26
 date-precision: day
 tags: null
 original:
-  title: null
+  title: unknown
   authors:
     - Ferenc Szilágyi
 license: null

--- a/plaintext/2020/09/quantum-electrodynamics.md
+++ b/plaintext/2020/09/quantum-electrodynamics.md
@@ -8,7 +8,7 @@ date: 2020-09-24
 date-precision: day
 tags: null
 original:
-  title: null
+  title: Quantum electrodynamics
   authors:
     - Contributors to Wikipedia
 license: Unknown license

--- a/plaintext/2021/02/pini.md
+++ b/plaintext/2021/02/pini.md
@@ -1,6 +1,6 @@
 ---
 title: pini
-description: null
+description: kon toki pi kalama musi ni li kama tan toki musi 'The End Poem' tan musi Manka. musi Manka li pona mute a.
 authors:
   - kala pona Tonyu
 proofreaders: null
@@ -12,14 +12,17 @@ tags:
   - lyrics
   - poetry
   - minecraft
-original: null
+original:
+  title: The End Poem
+  authors:
+    - Julian Gough
 license: null
 sources:
   - https://www.youtube.com/watch?v=VHLoVd_AikE
 archives: null
 preprocessing: Section headers are wrapped inside square brackets.
 accessibility-notes: null
-notes: null
+notes: kon toki pi kalama musi ni li kama tan toki musi 'The End Poem' tan musi Manka. musi Manka li pona mute a.
 ---
 
 \[musi #1]  \

--- a/plaintext/2021/02/sowejoki.md
+++ b/plaintext/2021/02/sowejoki.md
@@ -7,7 +7,10 @@ proofreaders: null
 date: 2021-02-16
 date-precision: day
 tags: null
-original: null
+original: 
+  title: Jaberwocky
+  authors:
+    - Lewis Carroll
 license: CC-BY-SA 4.0
 sources:
   - https://github.com/lipukule/site/blob/main/content/post/2021-02-16-sowejoki.md

--- a/plaintext/2021/05/kalama-nimi-pi-toki-pona.md
+++ b/plaintext/2021/05/kalama-nimi-pi-toki-pona.md
@@ -12,8 +12,8 @@ tags:
   - music
   - every word
 original:
-  title: null
-  authors: null
+  title: The Elements
+  authors: Tom Lehrer
 license: null
 sources:
   - https://www.youtube.com/watch?v=MryDuToQMsg

--- a/plaintext/2021/05/kalama-nimi-pi-toki-pona.md
+++ b/plaintext/2021/05/kalama-nimi-pi-toki-pona.md
@@ -13,7 +13,8 @@ tags:
   - every word
 original:
   title: The Elements
-  authors: Tom Lehrer
+  authors: 
+    - Tom Lehrer
 license: null
 sources:
   - https://www.youtube.com/watch?v=MryDuToQMsg

--- a/plaintext/2021/07/musi-moli.md
+++ b/plaintext/2021/07/musi-moli.md
@@ -7,7 +7,10 @@ proofreaders: null
 date: 2021-07-10
 date-precision: day
 tags: null
-original: null
+original:
+  title: Todesfuge
+  authors:
+    - Paul Celan
 license: CC-BY-SA 4.0
 sources:
   - https://github.com/lipukule/site/blob/main/content/post/2021-07-10-musi_moli.md

--- a/plaintext/2021/12/tenpo-santa-li-kama.md
+++ b/plaintext/2021/12/tenpo-santa-li-kama.md
@@ -8,7 +8,9 @@ proofreaders: null
 date: 2021-12-28
 date-precision: day
 tags: null
-original: null
+original:
+  title: A Visit from St. Nicholas
+  authors: Clement Clarke Moore
 license: CC-BY-SA 4.0
 sources:
   - https://www.youtube.com/watch?v=CcQQzeuSeZQ

--- a/plaintext/2021/12/tenpo-santa-li-kama.md
+++ b/plaintext/2021/12/tenpo-santa-li-kama.md
@@ -10,7 +10,8 @@ date-precision: day
 tags: null
 original:
   title: A Visit from St. Nicholas
-  authors: Clement Clarke Moore
+  authors: 
+    - Clement Clarke Moore
 license: CC-BY-SA 4.0
 sources:
   - https://www.youtube.com/watch?v=CcQQzeuSeZQ

--- a/plaintext/2022/06/jan-monsuta-loje.md
+++ b/plaintext/2022/06/jan-monsuta-loje.md
@@ -8,7 +8,10 @@ proofreaders: null
 date: 2022-06-10
 date-precision: day
 tags: null
-original: null
+original:
+  title: The Red Oni who Cried
+  authors:
+    - unknown
 license: CC-BY-SA 4.0
 sources:
   - https://www.youtube.com/watch?v=9VjPV9BpU2I

--- a/plaintext/2022/07/esun-pi-ijo-sin.md
+++ b/plaintext/2022/07/esun-pi-ijo-sin.md
@@ -7,7 +7,10 @@ proofreaders: null
 date: 2022-07-16
 date-precision: day
 tags: null
-original: null
+original:
+  title: “AU MAGASIN DE NOUVEAUTES”
+  authors:
+    - 李箱
 license: CC-BY-SA 4.0
 sources:
   - https://github.com/lipukule/site/blob/main/content/post/2022-07-16-ante-toki-pi-au-magasin-de-nouveautes-esun-pi-ijo-sin.md
@@ -15,7 +18,7 @@ sources:
 archives: null
 preprocessing: null
 accessibility-notes: null
-notes: null
+notes: See https://en.namu.wiki/w/%EA%B1%B4%EC%B6%95%EB%AC%B4%ED%95%9C%EC%9C%A1%EB%A9%B4%EA%B0%81%EC%B2%B4 for more information on the original
 ---
 
 mi ante e toki pi toki lili “AU MAGASIN DE NOUVEAUTES” tan jan Isan. sina ken pilin e ni: ona li nasa lili. jan Isan li pali ala e toki lili kepeken lawa pi toki lili. ona li lukin pali e ona kepeken nasin sin. toki ni li lon kulupu pi toki lili “leko pi pali tomo pi pini ala”. mi wile pana e toki lili ante lon kulupu ni.

--- a/plaintext/2022/08/li-pakala-tan-telo-loje-tan-sona-awen.md
+++ b/plaintext/2022/08/li-pakala-tan-telo-loje-tan-sona-awen.md
@@ -12,7 +12,7 @@ date-precision: day
 tags:
   - "fan fiction"
 original:
-  title: null
+  title: spilling wine (and maybe secrets)
   authors:
     - bonustrack
 license: null

--- a/plaintext/2022/08/tawa-tomo.md
+++ b/plaintext/2022/08/tawa-tomo.md
@@ -8,7 +8,7 @@ date: 2022-08-27
 date-precision: day
 tags: null
 original:
-  title: null
+  title:  Homeward Bound
   authors:
     - jan Marta Keen
 license: null

--- a/plaintext/2023/08/meli-pimeja.md
+++ b/plaintext/2023/08/meli-pimeja.md
@@ -6,7 +6,10 @@ authors:
 proofreaders: null
 date: '2023-08-21'
 date-precision: day
-original: null
+original:
+  title: Madamoiselle Noir
+  authors:
+    - Peppina
 tags:
   - music
   - translation

--- a/plaintext/2023/12/toki-musi-tan-jan-sapo-tan-jan-katulo.md
+++ b/plaintext/2023/12/toki-musi-tan-jan-sapo-tan-jan-katulo.md
@@ -9,7 +9,7 @@ date-precision: day
 tags:
   - poetry
 original:
-  title: null
+  title: Catullus 51
   authors:
     - Σαπφώ (jan Sapo)
     - C. Valerius Catullus (jan Katulo)

--- a/plaintext/2024/05/pini-weka.md
+++ b/plaintext/2024/05/pini-weka.md
@@ -9,9 +9,9 @@ date-precision: day
 tags:
   - poetry
 original:
-  title: null
+  title: L'infinito
   authors:
-    - Giacomo Leopardi, 1798–1837 (jan Jakomo Lopate)
+    - Giacomo Leopardi (jan Jakomo Lopate)
 license: CC-BY-SA 4.0
 sources:
   - https://liputenpo.org/pdfs/0026jaki.pdf

--- a/plaintext/2024/10/o-moli-ala-tawa-pimeja-pona-tenpo.md
+++ b/plaintext/2024/10/o-moli-ala-tawa-pimeja-pona-tenpo.md
@@ -9,9 +9,9 @@ date-precision: day
 tags:
   - poetry
 original:
-  title: null
+  title: Do not go gentle into that good night
   authors:
-    - jan Silan Toma
+    - Dylan Thomas
 license: CC-BY-SA 4.0
 sources:
   - https://liputenpo.org/pdfs/0029jan.pdf

--- a/plaintext/2024/12/sike-pipi.md
+++ b/plaintext/2024/12/sike-pipi.md
@@ -11,7 +11,10 @@ date-precision: day
 tags:
   - 'ao3'
   - 'music'
-original: null
+original:
+  title: Spiral of Ants
+  authors:
+    - Lemon Demon
 license: null
 sources:
   - https://archiveofourown.org/works/61372846

--- a/plaintext/unknown-year/unknown-month/nasin-pona-len.md
+++ b/plaintext/unknown-year/unknown-month/nasin-pona-len.md
@@ -10,9 +10,9 @@ tags:
   - translation
   - taoism
 original:
-  title: null
+  title: 非風非幡 (無門關)
   authors:
-    - unknown # added automatically during reschema
+    - 無門慧開
 license: CC0 1.0
 sources:
   - http://tokipona.net/tp/janpije/nasinpona-len.php  # dead link

--- a/plaintext/unknown-year/unknown-month/nasin-tawa.md
+++ b/plaintext/unknown-year/unknown-month/nasin-tawa.md
@@ -9,12 +9,18 @@ date-precision: none
 tags:
   - translation
   - prose
-original: null
+original:
+  title: Newton's Laws of Motion
+  authors:
+    - Isaac Newton
 license: CC BY-NC 3.0
 sources:
+  - http://anadder.com/toki_pona/nasin_tawa
   - http://failbluedot.com/toki_pona/nasin_tawa
 archives:
   - https://web.archive.org/web/20140305061738/http://failbluedot.com/toki_pona/nasin_tawa
+  - https://htmlpreview.github.io/?https://raw.githubusercontent.com/jan-Lope/Toki_Pona_lessons_English/gh-pages/toki-pona-lessons_en/index.html#SECTION00366000000000000000
+  - https://web.archive.org/web/20080719153453/http://anadder.com/toki_pona/nasin_tawa
 preprocessing: null
 accessibility-notes: null
 notes: null

--- a/plaintext/unknown-year/unknown-month/shahadah.md
+++ b/plaintext/unknown-year/unknown-month/shahadah.md
@@ -9,11 +9,11 @@ date-precision: none
 tags:
   - translation
   - religion
-  - islamRetro-Translation Back to English
+  - islam
+  - Retro-Translation Back to English
 original:
-  title: null
-  authors:
-    - unknown # added automatically during reschema
+  title: الشَّهَادَةُ
+  authors: null
 license: CC0 1.0
 sources:
   - http://tokipona.net/tp/janpije/shahadah.php  # dead link


### PR DESCRIPTION
Added an `original.title` and/or `original.author` to various files.

I've given 2020/07/sitelen-suwi an `original.title` of "unknown" because I couldn't track down the original either, but this way it'll display on [lipu.pona.la/adaptations](http://lipu.pona.la/adaptations)

Currently we indicate non-derivative posts with either `original = null` or `original = { title: null, authors: null }`, which seem to indicate the exact same thing... could do with some cleaning up - but it doesn't effect anything rn so that's for another day.