### PR TITLE
various content from tokipona.net corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,22 +56,23 @@ items:
 
 ## Sources
 
-| Name                                                  | Made / maintained by | Issue                                         | Claimed by            |
-|-------------------------------------------------------|----------------------|-----------------------------------------------|-----------------------|
-| lipu kule ([site][lk site] / [repo][lk repo])         | akesi Jan            | https://github.com/kulupu-lapo/poki/issues/9  | kala Asi              |
-| Writing contests ([site][um site] / [repo][um repo])  | jan Lakuse           | https://github.com/kulupu-lapo/poki/issues/11 | kala Asi              |
-| kalama sin ([site][ks site] / [ws][ks ws])            | various              | https://github.com/kulupu-lapo/poki/issues/12 | kala Asi              |
-| lipu tenpo ([site][lt site] / [repo][lt repo])        | jan Alonola          | https://github.com/kulupu-lapo/poki/issues/10 | ijo vivi              |
-| [TP Library][tonyu lib]                               | kala pona Tonyu      | https://github.com/kulupu-lapo/poki/issues/22 | jan Juwan             |
-| Personal websites                                     | various              | https://github.com/kulupu-lapo/poki/issues/17 | ijo vivi              |
-| Song collection ([yt][songs yt] / [docs][songs doc])  | jan Ke Tami          | No                                            | jan Juwan             |
-| [Wikisource]                                          | various              | No                                            |                       |
-| [kijetesantakalu o!][kije o]                          | jan Ke Tami          | No                                            | ijo vivi              |
-| [Archive Of Our Own][AO3]                             | various              | No                                            | ijo vivi              |
-| [jan Lentan's blog posts][Lentan]                     | jan Lentan           | No                                            | jan Kita              |
-| [lipu monsuta]                                        | soweli kina          | No                                            | jan Kita              |
-| [jan Telakoman's blog posts][Telakoman]               | jan Telakoman        | No                                            | jan Kita              |
-| [Storyweaver]                                         | various              | No                                            | jan Kita              |
+| Name                                                  | Made / maintained by | Issue                                          | Claimed by            |
+|-------------------------------------------------------|----------------------|------------------------------------------------|-----------------------|
+| lipu kule ([site][lk site] / [repo][lk repo])         | akesi Jan            | https://github.com/kulupu-lapo/poki/issues/9   | kala Asi              |
+| Writing contests ([site][um site] / [repo][um repo])  | jan Lakuse           | https://github.com/kulupu-lapo/poki/issues/11  | kala Asi              |
+| kalama sin ([site][ks site] / [ws][ks ws])            | various              | https://github.com/kulupu-lapo/poki/issues/12  | kala Asi              |
+| lipu tenpo ([site][lt site] / [repo][lt repo])        | jan Alonola          | https://github.com/kulupu-lapo/poki/issues/10  | ijo vivi              |
+| [TP Library][tonyu lib]                               | kala pona Tonyu      | https://github.com/kulupu-lapo/poki/issues/22  | jan Juwan             |
+| Personal websites                                     | various              | https://github.com/kulupu-lapo/poki/issues/17  | ijo vivi              |
+| Song collection ([yt][songs yt] / [docs][songs doc])  | jan Ke Tami          | No                                             | jan Juwan             |
+| [Wikisource]                                          | various              | No                                             |                       |
+| [kijetesantakalu o!][kije o]                          | jan Ke Tami          | No                                             | ijo vivi              |
+| [Archive Of Our Own][AO3]                             | various              | No                                             | ijo vivi              |
+| [jan Lentan's blog posts][Lentan]                     | jan Lentan           | No                                             | jan Kita              |
+| [lipu monsuta]                                        | soweli kina          | No                                             | jan Kita              |
+| [jan Telakoman's blog posts][Telakoman]               | jan Telakoman        | No                                             | jan Kita              |
+| [Storyweaver]                                         | various              | No                                             | jan Kita              |
+| [tokipona.net corpus][nltk-tp]                        | jan Mato             | https://github.com/kulupu-lapo/poki/issues/133 | jan Lilipe            |
 
 [lk site]:https://lipukule.org/
 [lk repo]:https://github.com/lipukule/lipu-kule
@@ -91,8 +92,7 @@ items:
 [lipu monsuta]:https://lipumonsuta.neocities.org/
 [Telakoman]:https://joelthomastr.github.io/tokipona/README_si
 [Storyweaver]:https://storyweaver.org.in/en/stories?language=Toki+Pona
-
-Sources like `ntlk-tp` are intensionally excluded from this list due to their scope being too different to our's and the lack of metadata in them.
+[nltk-tp]:https://github.com/matthewdeanmartin/tokipona.parser/tree/master/BasicTypes/Tp/Corpus
 
 ## Contributing
 

--- a/collections/fail-blue-dot.yaml
+++ b/collections/fail-blue-dot.yaml
@@ -6,7 +6,7 @@ items:
   - plaintext/unknown-year/unknown-month/jan-bokakio.md
   - plaintext/unknown-year/unknown-month/jan-en-soweli.md
   - plaintext/unknown-year/unknown-month/jan-lawa.md
-  - plaintext/2013/01/jan-lawa-lili.md
+  - plaintext/unknown-year/unknown-month/jan-lawa-lili.md
   - plaintext/unknown-year/unknown-month/jan-sewi.md
   - plaintext/unknown-year/unknown-month/jan-suansu.md
   - plaintext/unknown-year/unknown-month/kalama-musi-suli.md

--- a/plaintext/2002/10/jan-uluka-li-pilin-ike.md
+++ b/plaintext/2002/10/jan-uluka-li-pilin-ike.md
@@ -1,0 +1,63 @@
+---
+title: jan Uluka li pilin ike
+description: null
+authors:
+  - Yves Prudhomme
+proofreaders: null
+date: 2002-10-10
+date-precision: day # posted onto the yahoo forums. http://forums.tokipona.org/viewtopic.php?t=70
+tags:
+  - poem
+original: null
+license: All Rights Reserved
+sources:
+  - https://www.oocities.org/yves_prudhomme/toki_pona/jan_Uluka_li_pilin_ike.html
+archives:
+  - https://web.archive.org/web/0/http://www.geocities.com:80/yves_prudhomme/toki_pona/jan_Uluka_li_pilin_ike.html
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/GeocitiesRecovered/Yves%20Prudhomme/Yves%20Prudhome%20Uluka.txt
+preprocessing: 'mi ante e nimi pakala "kawa" tawa nimi pona "lawa".'
+accessibility-notes: null
+notes: 'Viktoro li ante e nimi "Uluk" tawa nimi "Uluka".'
+---
+jan Uluka wan li pana e telo oko.  
+jan Uluka li wan, li pilin ike.
+
+jan Uluka ni li wile e seme?
+
+seli li pona tawa jan Uluka.  
+moku e luka jan li pona tawa jan Uluka.  
+pali e lupo pi sinpin jan li pona tawa jan Uluka.  
+anpa e kiwen tawa lawa jan li pona tawa jan Uluka.  
+tu e lawa jan li pona tawa jan Uluka.
+
+jan Uluka li wile kute e kalama musi utala.  
+jan Uluka li wile lukin e telo loje pi jan lili mute.
+
+akesi jelo li jan pona pi jan Uluka.  
+pipi pimeja en loje li jan pona pi jan Uluka.  
+pipi mute li pona tawa jan Uluka.
+
+ijo palaka li pona tawa jan Uluka.  
+ijo jaki li pona tawa jan Uluka.  
+jan moli li pona tawa jan Uluka.  
+tenpo pimeja li pona tawa jan Uluka.
+
+jan Uluka li wile palaka seli e tomo jan.  
+jan Uluka li wile moku e luka jan wan.
+
+taso ala!
+
+utala li lon ala a!  
+kulupu utala li lon ala a!  
+pimeja kin seli li lon ala a!  
+jan Uluka li jo ala e ilo utala wan!
+
+tenpo suno li lon. suno mute li lon!  
+suno li pana e seli tawa selo pi jan Uluka!  
+kaso li lon! waso mute li lon!  
+waso mute li pana e kalama musi waso!
+
+ni li pona ala tawa jan Uluka!
+
+jan Uluka li wile e luka jan insa uta.  
+jan Uluka li pilin ike.

--- a/plaintext/2002/10/sijelo-pi-nasin-pona.md
+++ b/plaintext/2002/10/sijelo-pi-nasin-pona.md
@@ -1,0 +1,55 @@
+---
+title: sijelo pi nasin pona
+description: Translation of the first chapter of Tao Te Ching
+authors:
+  - Yves Prudhomme
+proofreaders: null
+date: 2002-10-10
+date-accuracy: day # posted on the yahoo forums. http://forums.tokipona.org/viewtopic.php?t=71
+tags:
+  - translation
+  - taoism
+original:
+  title: 道德經
+  authors:
+    - 老子
+license: All Rights Reserved
+sources:
+  - https://www.oocities.org/yves_prudhomme/toki_pona/nasin_pona/
+archives:
+  - http://web.archive.org/web/20250930073101/https://www.oocities.org/yves_prudhomme/toki_pona/nasin_pona/
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/GeocitiesRecovered/Yves%20Prudhomme/tempo%20suno%20ni%20pi%20Iwa.txt
+preprocessing: null
+accessibility-notes: null
+notes: toki ni li tan tenpo pi weka mute. nasin toki ona li nasa tawa jan toki pi tenpo ni.
+---
+kin toki sona pi pona mute li nasin pona ala.  
+kin nimi pi pona mute li nimi ala e nasin pona.  
+nimi ala la jan li ken tawa nasin pona.  
+nimi ala la jan li ken sona ni.
+
+tawa nasin pona la  
+jan li tawa kan ala pilin pi pali pini palaka.  
+ni li pali e wawa pi jan.  
+wawa ni li pona tawa jan ale.
+
+tawa nasin pona la  
+jan li wile ala nimi.  
+taso toki e ni la jan li kepeken e nimi.  
+nasin ni la mi mute li ken toki pona sike ni.  
+nasin ni la mi mute li toki nasa ala.  
+nasin sama ala la jan li ken wile tawa.  
+kepeken nimi la mi mute li sona e nasin ni, li sona e nasin sama ala.
+
+sona en toki lawa en nimi la  
+jan li sona e sitelen selo pi nasi pona.  
+taso ijo lawa ni ala la mi tute li ken kin tawa nasin pona.
+
+sona en tawa li lon.  
+lon li jo e nasin lukin mute.  
+ni li ken pana e nasa nanpa.
+
+kepeken e nasin pona la  
+mi mute li kama suli.  
+mi tawa insa ala sike pi nasa nanpa.  
+nasin ni la mi tawa nasin pona.

--- a/plaintext/2002/10/sijelo-pi-nasin-pona.md
+++ b/plaintext/2002/10/sijelo-pi-nasin-pona.md
@@ -5,7 +5,7 @@ authors:
   - Yves Prudhomme
 proofreaders: null
 date: 2002-10-10
-date-accuracy: day # posted on the yahoo forums. http://forums.tokipona.org/viewtopic.php?t=71
+date-precision: day # posted on the yahoo forums. http://forums.tokipona.org/viewtopic.php?t=71
 tags:
   - translation
   - taoism

--- a/plaintext/2002/10/tenpo-suno-ni-iwa.md
+++ b/plaintext/2002/10/tenpo-suno-ni-iwa.md
@@ -1,0 +1,144 @@
+---
+title: tenpo suno pi Iwa
+description: Four toki pona diary entries from 2002
+authors:
+  - Yves Prudhomme
+proofreaders: null
+date: 2002-10-10
+date-precision: month # mentions uploading other pages which are known to have been posted on 2002-10-10. other sections were presumably added soon after
+tags:
+  - diary
+  - blog
+original: null
+license: All Rights Reserved
+sources:
+  - https://www.oocities.org/yves_prudhomme/toki_pona/tenpo_suno_ni/index.html
+  - https://www.oocities.org/yves_prudhomme/toki_pona/tenpo_suno_ni/pini.html
+archives:
+  - https://web.archive.org/web/20071118095058/http://www.geocities.com/yves_prudhomme/toki_pona/tenpo_suno_ni/index.html
+  - https://web.archive.org/web/20250930075638/https://www.oocities.org/yves_prudhomme/toki_pona/tenpo_suno_ni/pini.html
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/GeocitiesRecovered/Yves%20Prudhomme/tempo%20suno%20ni%20pi%20Iwa.txt
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/GeocitiesRecovered/Yves%20Prudhomme/Yvess%20Prudhomme%202002%20tenpo%20pini.txt
+preprocessing: 'mi ante e nimi pakala "anba" tawa nimi pona "anpa"'
+accessibility-notes: null
+notes: toki ni li tan tenpo pi weka mute. nasin toki ona li nasa tawa jan toki pi tenpo ni.
+---
+## tenpo suno ni
+toki! tenpo suno ni mi wile e lape.  
+pata kin meli olin pi pata li tawa tomo ona.  
+mi kama wan. ni li pona tawa mi.
+
+pata kin jan pona li pona tawa mi.  
+taso kama wan li pona tawa mi.  
+ijo tu ni li pona.
+
+tenpo suno ni la telo sewi li kama anpa.  
+pimeja li lon. lete li lon.  
+mi awen lon tomo mi.  
+seli li lon.
+
+mi pali mute. mi wile e pini pali.  
+mi wile ala e pali.
+
+pona o kan sina!
+
+## tenpo suno pini
+
+pata mi kin meli olin pi pata mi li lon. pona!  
+mi kin ona li moku kan.  
+mi kin ona li toki kan.  
+jan mama li pona.  
+ijo ala li sama e jan mama.
+
+tenpo pimeja pini la mi moku e ko wawa nasa mute.  
+jan pona mute li lon.  
+ni li ike mute li pona mute. ni li nasa.  
+nasin ni li lon.
+
+tomo pi telo nasa la mi moku e mute.  
+mi lukin e meli mute.  
+mi toki e meli pi pona lukin mute.  
+tenpo kama li mi kin ona li kama kan.  
+pona!
+
+tenpo suno ni la mi lape mute.  
+mi wile mute e lape.  
+wawa li lon ala.  
+pona o kan sina!
+
+## tenpo suno pini
+
+tenpo pimeja pini la mi kin jan pona mi tu li tawa tomo pi telo nasa.  
+mi lukin e meli mute. mi toki tawa meli.  
+ni li pona.  
+kalama musi li lon.  
+mi pali e tawa noka musi.  
+mi moku e telo nasa pi mute ike.  
+tenpo suno ni la mi pilin e lawa kiwen. a!
+
+ma Kanata la suno li lon ala.  
+seli li lon ala.  
+jan li jo e len suli.  
+mi pilin ike li pilin pona.
+
+tenpo suno kama la pata mi li kama tan ma Amewika.  
+ona li jan Ani.  
+ona li jan pi pali sijelo.  
+ni li jo e linja pimeja li oko laso.  
+ona li kalama mute ala.
+
+meli olin pi jan Ani li kama kan.  
+ona li jan Pan.  
+jan Pan li lili. ona li suwi.  
+ona li pata meli mi.  
+ni li jo e linja jelo suno li oko
+
+ni li pona tawa mi.
+
+tomo mi la ale li lape.  
+tomo mi la kin lili.  
+mi jo e supa lape kin wan.  
+mi pali e seme?  
+nasin ni li lon.
+
+## tenpo suno pini
+
+tenpo suno ni la mi pali e lipu pi ilo sona.  
+mi sewi e lipu tu wan.
+
+mi pali e lipu sike [jan Uluka pi pilin ike](jan-uluka-li-pilin-ike).  
+ni li toki awen mi.  
+jan Uluka li jaki kin utala kin ike.  
+jan Uluka li pona tawa mi.
+
+mi pali e lipu sike [nasin pona](sijelo-pi-nasin-pona).  
+ni li toki musi sewi.  
+ona li kama tan ma Sonko.  
+ona li kama tan toki Sonko.  
+tenpo pini la jan Sonko sona li toki e toki musi ni.  
+ona li pona tawa jan Sonko mute.  
+ona li pona tawa jan pi ma ale.  
+nasin pona li toki musi suli.
+
+tenpo suno ni la mi pali e lipu sike [tomo palisa](tomo-palisa-pi-papeli).  
+mi ante toki ni insa toki pona.  
+ona li toki sike jan sewi Jawe.  
+ona li toki suli tawa jan pi nasin sewi Jawatu.  
+ona li toki suli tawa jan pi nasin sewi Kolisu.  
+jan ale ni li lukin sewi tawa mama mije suli Jawe.
+
+ona li toki suli tawa jan pali toki.  
+mi sona ala tan.
+
+tenpo suno ni la mi tawa tomo moku.  
+mi moku e telo pimeja seli.  
+mi moku e moku walo sike.  
+mi lukin e meli.  
+meli ni li pona lukin.  
+mi lukin e lipu toki pi ijo sin.  
+ale ni li pona tawa mi.
+
+mi pali e mute ala.  
+mi ken ala lukin e pini pi pali mi.  
+ni li ike tawa mi.  
+mi wile e pini e pali. 

--- a/plaintext/2002/10/tomo-palisa-pi-papeli.md
+++ b/plaintext/2002/10/tomo-palisa-pi-papeli.md
@@ -1,0 +1,40 @@
+---
+title: tomo palisa pi Papeli
+description: null
+authors:
+  - Yves Prudhomme
+proofreaders: null
+date: 2002-10-09
+date-precision: day # posted onto the yahoo forums. http://forums.tokipona.org/viewtopic.php?t=69 
+tags:
+  - translation
+original:
+  title: Tower of Babel
+  authors: null
+license: All Rights Reserved
+sources:
+  - https://www.oocities.org/yves_prudhomme/toki_pona/tomo_palisa_pi_Papeli.html
+archives:
+  - https://web.archive.org/web/20250930071921/https://www.oocities.org/yves_prudhomme/toki_pona/tomo_palisa_pi_Papeli.html
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/GeocitiesRecovered/Yves%20Prudhomme/YP%20tower%20of%20babel%20tp%20only.txt
+preprocessing: 'mi weka e toki Inli tan'
+accessibility-notes: null
+notes: toki ni li tan tenpo pi weka mute. nasin toki ona li nasa tawa jan toki pi tenpo ni.
+---
+tenpo ni la ma ale li jo e toki wan. nimi mute ala li lon.
+
+jan mute li kama tan ma Keden. ona li lukin e ma supa lon ma Sinala. lon ma la ona li tomo.
+
+mije li toki tawa jan pona ona. mije ni li toki e: "o sina kama! o mi en sina li pali e ijo kiwen telo mute, li seli e ona." kiwen seli ni li kiwen wawa tawa ona. ma telo li ilo kepeken tawa ona.
+
+ona li toki e: "o sina kama! o mi en sina li pali e ma tomo, li pali e tomo palisa suli suli. o lawa pi tomo palisa ni li lon sewi. o mi en sina li kama lawa, li jo e nimi lawa. mi wile ala mute lon selo pi ma ale."
+
+jan sewi Jawe li anpa. ona li wile lukin e ma tomo en tomo palisa. jan pi ma anpa li pali e ijo ni.
+
+jan sewi Jawe li toki e: "o sina lukin! kulupu ma li wan. ona ale li jo e toki kin wan. ona li kama pali e ni. tenpo la pali pi wile ona li kin kama."
+
+"o mi mute kama! mi mute li anpa, li nasa e toki ona. tenpo la jan li kute ala e toki pi jan pona."
+
+tenpo la jan sewi Jawe li mute jan ni tawa selo pi ma ale. ona kama pali ala e ma tomo.
+
+tan ni la nimi pi ma tomo li "papeli." ma ni la jan sewi Jawe li nasa e toki pi jan ale. 

--- a/plaintext/2004/06/lipu-sewi.md
+++ b/plaintext/2004/06/lipu-sewi.md
@@ -10,7 +10,8 @@ tags:
   - translation
 original:
   title: Book of Genesis
-  authors: authors of the Bible
+  authors: 
+    - authors of the Bible
 license: null
 sources:
   - https://www.angelfire.com/weird2/helloworld/tokiponabible.html

--- a/plaintext/2004/06/lipu-sewi.md
+++ b/plaintext/2004/06/lipu-sewi.md
@@ -1,0 +1,41 @@
+---
+title: lipu sewi
+description: Translations from Book of Genesis (Garden of Eden, Cain & Abel, Noah's Arc, Tower of Babel)
+authors:
+  - Stephen Todd Pope
+proofreaders: null
+date: 2004-06-01
+date-precision: month # website linked to on the yahoo group 2004-06-01 ("tenpo ni la mi pali e lipu sin. ona li pini ala. tenpo kama lili la mi pini e ona"), and linked to in https://web.archive.org/web/20040901002933/http://www.geocities.com/stephentoddpope/tokiponahome. no direct archive of the original page exists.
+tags:
+  - translation
+original:
+  title: Book of Genesis
+  authors: authors of the Bible
+license: null
+sources:
+  - https://www.angelfire.com/weird2/helloworld/tokiponabible.html
+archives:
+  - https://web.archive.org/web/20150121034129/https://www.angelfire.com/weird2/helloworld/tokiponabible.html
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/GeocitiesRecovered/Stephen%20Todd%20Pope/StephenToddPope%20Jan%20Siwen.txt
+preprocessing: null
+accessibility-notes: null
+notes: null
+---
+## jan sewi Jawe li pali e jan (creation)
+
+jan sewi Jawe li pali e jan li pana e nimi tawa ona. jan Adam li lon. jan Adam li wile pana e nimi tawa soweli ali e kala ali e waso ali e akesi ali. jan Adam li wile jo e meli. jan sewi Jawe li pana e meli tawa jan Adam. jan Adam li pana e nimi "Eve" tawa meli ni. jan sewi Jawe li toki lawa tawa e ni tawa jan tu ni: "o moku ala e kili ni. ona li ken pana e sona ike e sona pona." tenpo li pini. jan Eve li toki tawa akesi ike. akesi ike li toki e ni: "sina wile sona la o moku e kili sona." jan Eve li moku e kili sona. jan Eve li pana e kili tawa jan Adam. jan Adam li moku e kili. ona li lukin e ni: ona li jo ala e len. ona li kepeken e len kasi. jan sewi Jawe li lon ma kili. jan sewi Jawe li toki e ni: "jan Adam o! jan Eve o! sina lon seme?" jan Adam li toki e ni: "mi lon." jan sewi Jawe li toki e ni: "sina moku ala moku e kili sona?" jan Adam li toki e ni: "mi moku e ona. mi pilin ike tan ni." jan sewi Jawe li pana e len tawa jan Adam en tawa jan Eve. jan sewi Jawe li toki e ni: "toki mi li lawa ala e sina. jan Adam o, sina ken ala awen lon ma pona. sina wile pali. jan Eve o, sina wile pana e jan lili.
+
+
+## jan Cain e jan Abel
+
+jan Eve li pana e jan lili tu. jan lili wan li jo e nimi. ona li "Cain." jan lili tu li jo e nimi. ona li "Abel". jan Cain li pali e kili. jan Abel li pali e soweli. tenpo li pini. jan Abel li pana e soweli tawa jan sewi Jawe. jan sewi Jawe li olin e soweli jan Abel. jan Cain li pana e kili tawa jan sewi Jawe. taso jan sewi Jawe li olin lili e kili jan Cain. jan Cain li moli e jan Able tan ni. jan sewi Jawe toki e ni tawa jan Cain: "sina wile ala jo e kili! jan ala li moki e sina."
+
+
+## tomo tawa suli pi telo
+
+jan ale li ike. tan ni,jan sewi Jawe li wile pakala a ma. taso jan Noah li pona. jan sewi Jawe li pakala ala e ona tan ni. jan sewi Jawe li toki e ni tawa jan Noah "sina wile pali e tomo tawa suli pi telo. telo mute li kama tawa ma. sina wile pana e soweli e akesi e waso ale lon e tomo tawa pi telo. tenpo kama lili la mi wile moli e jan ale. mi wile moli ala e sina e kulupu sina. tenpo pini. telo mute li kama tawa ma. tenpo mute pini. jan Noah li pana e waso. taso ona li lukin ala e ma. tenpo pini lili la jan Noah li pana e waso: ona li kama ala.tan ni: jan Noah sona e ni: ma li lon. tomo tawa pi telo li lon e nena ma. nimi pi nena ma li "Ararat". jan sewi Jawe li pali e kule sewi. ona li pali e ni tan ni. ona li toki e ni tawa jan Noah : tenpo kama la mi wile pakala ala e ma kepeken e telo.
+
+
+## ma tomo pi toki nasa
+
+jan ali li kepeken e toki wan sama.jan li kama tan nasin pi kama suno li kama tawa ma Sinale li awen lon ni. jan li toki e ni: "o kama! mi mute o pali e kiwen. o seli e ona." jan mute li toki e ni: "o kama! mi mute o pali e tomo mute e tomo palisa suli. sewi pi tomo palisa li lon sewi kon. nimi pi mi mute o kama suli! mi wile ala e ni: mi mute li lon ma ante mute." jan sewi Jawe li kama anpa li lukin e ma tomo e tomo palisa. jan sewi Jawe li toki e ni: jan li lon ma wan li kepeken e toki sama li pali e tomo palisa. tenpo ni la ona mute li ken pali e ijo ike mute. mi wile tawa anpa li wile pakala e toki pi jan mute ni. mi wile e ni: jan li sona ala e toki pi jan ante.jan sewi Jawe li kama e ni: jan li lon ma mute li ken ala pali e tomo. nimi pi ma tomo ni li toki nasa tan ni: jan sewi Jawe li pakala e toki pi jan ali. tan ma tomo toki nasa la jan sewi Jawe li tawa e jan tawa ma mute.

--- a/plaintext/2004/06/o-toki-pi-jan-sewi.md
+++ b/plaintext/2004/06/o-toki-pi-jan-sewi.md
@@ -1,0 +1,25 @@
+---
+title: o toki pi jan sewi
+description: null
+authors:
+  - Stephen Todd Pope
+proofreaders: null
+date: 2004-06-01
+date-precision: month # website linked to on the yahoo group 2004-06-01 ("tenpo ni la mi pali e lipu sin. ona li pini ala. tenpo kama lili la mi pini e ona"), and linked to in https://web.archive.org/web/20040901002933/http://www.geocities.com/stephentoddpope/tokiponahome. no direct archive of the original page exists.
+tags:
+  - translation
+original:
+  title: Lord's Prayer
+  authors: authors of the Bible
+license: null
+sources:
+  - https://www.angelfire.com/weird2/helloworld/tokiponabible.html
+archives:
+  - https://web.archive.org/web/20150121034129/https://www.angelfire.com/weird2/helloworld/tokiponabible.html
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/GeocitiesRecovered/Stephen%20Todd%20Pope/StephenToddPope%20Jan%20Siwen.txt
+preprocessing: null
+accessibility-notes: null
+notes: null
+---
+mama pi mi mute o, sina lon ma sewi. nimi sina li pona. ma sina o kama. o pali e wile sina lon ma sewi en lon ma. o pana e moku pi tenpo suno ni tawa mi mute. o weka e pali ike mi. sama la o weka e pali ike pi jan ante. o kama e ni: mi wile ala ike. o lawa e mi tan ike. tenpo ali la ma en ken en pona li pi sina. Amen.
+

--- a/plaintext/2004/06/o-toki-pi-jan-sewi.md
+++ b/plaintext/2004/06/o-toki-pi-jan-sewi.md
@@ -10,7 +10,8 @@ tags:
   - translation
 original:
   title: Lord's Prayer
-  authors: authors of the Bible
+  authors: 
+    - authors of the Bible
 license: null
 sources:
   - https://www.angelfire.com/weird2/helloworld/tokiponabible.html

--- a/plaintext/2004/06/son-23.md
+++ b/plaintext/2004/06/son-23.md
@@ -1,0 +1,35 @@
+---
+title: son 23
+description: null
+authors:
+  - Stephen Todd Pope
+proofreaders: null
+date: 2004-06-01
+date-precision: month # website linked to on the yahoo group 2004-06-01 ("tenpo ni la mi pali e lipu sin. ona li pini ala. tenpo kama lili la mi pini e ona"), and linked to in https://web.archive.org/web/20040901002933/http://www.geocities.com/stephentoddpope/tokiponahome. no direct archive of the original page exists.
+tags: 
+  - translation
+original:
+  title: unknown # presumably it's some passage from the bible.
+  authors: unknown
+license: null
+sources:
+  - https://www.angelfire.com/weird2/helloworld/tokiponabible.html
+archives:
+  - https://web.archive.org/web/20150121034129/https://www.angelfire.com/weird2/helloworld/tokiponabible.html
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/GeocitiesRecovered/Stephen%20Todd%20Pope/StephenToddPope%20Jan%20Siwen.txt
+preprocessing: null
+accessibility-notes: null
+notes: null
+---
+jan sewi li lawa e mi.
+mi wile ala.
+tan sina, mi lape lon ma.
+sina lawa e mi tawa telo.
+tan sina, mi pona.
+sina lawa e mi lon nasin sewi tan nimi sina.
+mi tawa lon nasin pi ike, sina poka e mi.
+ijo sina li pona tawa mi.
+sina pali e moku. sina pana e ona tawa mi e jan ike mi.
+sina pana e telo sewi lon mi.
+tenpo ale la ale li pona.
+tenpo ale la mi awen lon tomo sina.   

--- a/plaintext/2004/06/son-23.md
+++ b/plaintext/2004/06/son-23.md
@@ -10,7 +10,8 @@ tags:
   - translation
 original:
   title: unknown # presumably it's some passage from the bible.
-  authors: unknown
+  authors: 
+    - unknown
 license: null
 sources:
   - https://www.angelfire.com/weird2/helloworld/tokiponabible.html

--- a/plaintext/2005/09/toki-utala-Supaka.md
+++ b/plaintext/2005/09/toki-utala-Supaka.md
@@ -1,0 +1,44 @@
+---
+title: ma tomo Pape
+description: null
+authors:
+  - jan Pije
+proofreaders: null
+date: 2005-09-22
+date-precision: year # first capture is on a domain that was last updated in september 2005 (compare https://web.archive.org/web/200705/http://tokipona.esperanto-jeunes.org with https://web.archive.org/web/2006/http://toki.dm7.net/), it wasn't listed in the site's index in feb 2005 though (https://web.archive.org/web/2005/http://tokipona.nytka.org/text/text.html -- but it was added by 22 June 2006)
+tags: null
+original:
+  title: Chewbacca defense (South Park)
+  authors:
+    - Trey Parker
+    - Matt Stone
+license: null
+sources:
+  - https://web.archive.org/web/20070312023405/http://tokipona.esperanto-jeunes.org:80/text/chew.html
+  - https://web.archive.org/web/20070728134723/http://bknight0.myweb.uga.edu/toki/text/chew.html
+archives:
+  - https://web.archive.org/web/20070312023405/http://tokipona.esperanto-jeunes.org:80/text/chew.html
+  - https://web.archive.org/web/20070728134723/http://bknight0.myweb.uga.edu/toki/text/chew.html
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Pije/Southpark%20SOME%20ENGLISH.txt
+preprocessing: null
+accessibility-notes: null
+notes: 'tenpo 2007 anu tenpo poka la jan Pije li ante lili e toki ni. ona li ante e "lon poka pi" tawa "poka" e "ala!" tawa "sona ala!" e "li sina" tawa "la sina". lipu ni li jo e ante ni'
+---
+jan pi kulupu sona o, jan toki pi jan Chef li wile mute e ni: sina pilin e ni: tenpo pini la jan Chef li sitelen e toki musi "Stinky Britches." toki ona li wawa. a! mi pilin ike tawa jan Chef.
+
+taso jan pi kulupu sona ni o, mi wile e ni: sina pilin pi ijo pini wan. jan pi kulupu sona o, ni li jan Supaka. jan Supaka li tan kulupu Waki pi ma Kise. taso jan Supaka li awen lon ma Ento. o pilin. ni li nasa! jan Waki li suli mute. jan Iwa li lili mute. jan Waki li wile awen lon ma Ento poka jan Iwa tan seme? ni li nasa!
+
+taso sina wile pilin kin e ni: ni li suli ala suli tawa toki utala ni? ala! jan sona o, ona li lili tawa toki utala ni! ona li nasa!
+
+o lukin e mi. mi jan toki tawa kulupu suli pi kalama musi li toki pi jan Supaka. ni li sona ala sona? jan sona o, toki mi li nasa. ala li sona!
+
+o pilin. sina lon tomo sona li pilin li ante e toki awen Emancipation Proclamation. ... ona li sona ala sona? sona ala! jan pi kulupu sona o, ona li nasa.
+
+jan Supaka li awen lon ma Ento la sina ken ala toki e ike pi jan ante. mi pini toki.
+
+ 
+jan pi kulupu sona o, sina ken ante e pilin tawa jan Chef. mi sona e ni: ona li ike lukin. taso jan sona o, ni li Supaka. tenpo lili la o pilin -- ni li nasa. ali pi jan Chef li ken anpa. mi toki pi jan Supaka tan seme? tan seme? mi ken toki e tan: mi sona ala.
+
+ona li nasa. jan Supaka li nasa la sina ken ala toki e ike pi jan Chef.
+
+a. o lukin e soweli. o lukin e soweli nasa!

--- a/plaintext/2006/02/lipu-pi-jan-pona-sewi-matejo.md
+++ b/plaintext/2006/02/lipu-pi-jan-pona-sewi-matejo.md
@@ -1,0 +1,35 @@
+---
+title: lipu pi jan pona sewi Matejo 16:18-19
+description: null
+authors:
+  - jan Ke
+proofreaders: null
+date: 2006-02-11
+date-precision: year # posted to the yahoo group 2004-06-11 with a line-by-line translation showing different content. trusting archive date
+tags: null
+original:
+  title: Gospel of Matthew 16:18-19
+  authors: authors of the Bible
+license: null
+sources:
+  - https://web.archive.org/web/20060211005042/http://geocities.com/silverwings_88/keiportal
+archives:
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/GeocitiesRecovered/Kei's%20Portal.txt
+preprocessing: null
+accessibility-notes: null
+notes: null
+---
+
+# jan sewi Jawe o pana e pona tawa sina ale!
+
+# o kama pona!
+
+mi wile sitelen e ni tawa sina. lipu ni li lon nasin Katolike en toki nasin tawa toki pona. ona ken toki e wile tawa jan sewi Jawe anu mama Mewi en jan pona sewi mute lon sewi pona.
+
+nasin mute li pona. nasin Katolike li kin pona tan ni: jan Jesu li kama pana e nasin Katolike tawa jan pona ona Peto.
+
+> "sina jan Peto. mi pali e tomo pi jan sewi lon kiwen ni. lupa lon ma pi ike ale li ken ala pakala e ona.
+>
+> mi pana e ilo open tawa ma pi pona ale tawa sina. sina awen e ijo lon ma la, ijo li awen lon ma pi pona ale. sina weka e ijo lon ma la, ijo li weka lon ma pi pona ale."
+
+lipu pi jan pona sewi Matejo 16:18-19

--- a/plaintext/2006/02/lipu-pi-jan-pona-sewi-matejo.md
+++ b/plaintext/2006/02/lipu-pi-jan-pona-sewi-matejo.md
@@ -9,7 +9,8 @@ date-precision: year # posted to the yahoo group 2004-06-11 with a line-by-line 
 tags: null
 original:
   title: Gospel of Matthew 16:18-19
-  authors: authors of the Bible
+  authors: 
+    - authors of the Bible
 license: null
 sources:
   - https://web.archive.org/web/20060211005042/http://geocities.com/silverwings_88/keiportal

--- a/plaintext/2007/06/blue-sky.md
+++ b/plaintext/2007/06/blue-sky.md
@@ -1,0 +1,41 @@
+---
+title: Blue Sky
+description: null
+authors:
+  - jan Pije
+proofreaders: null
+date: 2007-06-24
+date-precision: day # Archived on July 28th, Linked to in a June 24th archive which lacked the link on June 22th.
+tags: 
+  - lyrics
+original:
+  title: Blue Sky
+  authors:
+    - The Allman Brothers Band
+license: Public Domain # https://web.archive.org/web/20110809134608/http://bknight0.myweb.uga.edu/toki/copyright.html
+sources:
+  - "https://web.archive.org/web/20070728134131/http://bknight0.myweb.uga.edu/toki/text/allman.html#Blue Sky"
+archives:
+  - https://web.archive.org/web/20070728134131/http://bknight0.myweb.uga.edu/toki/text/allman.html#Blue Sky
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Pije/Allman%20brothers%20Blue%20Sky.txt
+preprocessing: mi poki e toki. mi weka e toki Inli tan.
+accessibility-notes: null
+notes: null
+---
+
+mi tawa poka telo. toki musi suwi a. telo li pini ala tawa.  
+nasin ona li lili tawa ona.  
+waso laso o tawa ala weka. mi wile taso tawa lon nasin ni.
+
+suno pi tenpo suno sin li pana e sona pona tawa mi.
+
+sina sewi laso mi. sina tenpo suno mi.  
+sina olin e mi la mi pilin sewi.  
+o olin e mi a.
+
+ni li tenpo suno pi tomo sewi. mi kute e ilo kalama pi tomo sewi ni.  
+mi tawa ma Kawalana. tenpo kama lili la mi lon ma ni.
+
+sina sewi laso mi. sina tenpo suno mi.  
+sina olin e mi la mi pilin sewi.  
+o olin e mi a.

--- a/plaintext/2007/06/melissa.md
+++ b/plaintext/2007/06/melissa.md
@@ -1,0 +1,48 @@
+---
+title: Revival
+description: null
+authors:
+  - jan Pije
+proofreaders: null
+date: 2007-06-24
+date-precision: day # Archived on July 28th, Linked to in a June 24th archive which lacked the link on June 22th.
+tags: 
+  - lyrics
+original:
+  title: Melissa
+  authors:
+    - The Allman Brothers Band
+license: Public Domain # https://web.archive.org/web/20110809134608/http://bknight0.myweb.uga.edu/toki/copyright.html
+sources:
+  - https://web.archive.org/web/20070728134131/http://bknight0.myweb.uga.edu/toki/text/allman.html#Melissa
+archives:
+  - https://web.archive.org/web/20070728134131/http://bknight0.myweb.uga.edu/toki/text/allman.html#Melissa
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Pije/Allman_Melissa.txt
+preprocessing: 'jan Pije li toki e ni: "[These three lines are very poetic. Out of respect for the songwriter, I have chosen not to translate these lines because doing so would require an excessive manipulation of the songwriter's words.]". mi lili e ni tawa "[...]". mi poki tu tu e toki. mi weka e toki Inli tan.'
+accessibility-notes: null
+notes: null
+---
+nasin li kama li tawa. a.  
+jan tawa pi tomo ala li tawa poka telo weka tan poka telo ni.  
+ona li sona e jan mute li olin e jan ala.  
+ona li pilin ike. ona li musi.  
+taso ona li wile tawa ma tomo ona tan  
+jan Melisa suwi. a.
+
+tomo tawa linja a. tomo lili ali li lukin sama. sama a.  
+jan ala li sona e nimi pi jan tawa ni.  
+ona li wile poka jan ante la jan li kute ala e kalama ona.  
+ona li lape la ona li jo ala e len pi pilin pona.  
+ona li lape la ona li pilin  
+pi jan Melisa suwi. a.
+
+tenpo suno sin li lon.  
+ona li tawa sin.  
+suno li lon linja lawa ona.  
+sina lukin e ona la sina pilin e ni: ali li lili tawa ona.  
+jan tawa pi tomo ala o kama jo e ijo sina. o tawa. o tawa.  
+
+nasin o, sina weka ala weka e ona?  
+[...]  
+taso mi sona e ni: ona li jo ala e jan Melisa la ona li awen ala.  
+ona li jo ala e jan Melisa la ona li awen ala.

--- a/plaintext/2007/06/melissa.md
+++ b/plaintext/2007/06/melissa.md
@@ -18,7 +18,7 @@ sources:
 archives:
   - https://web.archive.org/web/20070728134131/http://bknight0.myweb.uga.edu/toki/text/allman.html#Melissa
   - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Pije/Allman_Melissa.txt
-preprocessing: 'jan Pije li toki e ni: "[These three lines are very poetic. Out of respect for the songwriter, I have chosen not to translate these lines because doing so would require an excessive manipulation of the songwriter's words.]". mi lili e ni tawa "[...]". mi poki tu tu e toki. mi weka e toki Inli tan.'
+preprocessing: "jan Pije li toki e ni: '[These three lines are very poetic. Out of respect for the songwriter, I have chosen not to translate these lines because doing so would require an excessive manipulation of the songwriter's words.]'. mi lili e ni tawa '[...]'. mi poki tu tu e toki. mi weka e toki Inli tan."
 accessibility-notes: null
 notes: null
 ---

--- a/plaintext/2007/06/midnight-rider.md
+++ b/plaintext/2007/06/midnight-rider.md
@@ -1,0 +1,42 @@
+---
+title: Midnight Rider
+description: null
+authors:
+  - jan Pije
+proofreaders: null
+date: 2007-06-24
+date-precision: day # Archived on July 28th, Linked to in a June 24th archive which lacked the link on June 22th.
+tags: 
+  - lyrics
+original:
+  title: Midnight Rider
+  authors:
+    - The Allman Brothers Band
+license: Public Domain # https://web.archive.org/web/20110809134608/http://bknight0.myweb.uga.edu/toki/copyright.html
+sources:
+  - https://web.archive.org/web/20070728134131/http://bknight0.myweb.uga.edu/toki/text/allman.html#Midnight Rider
+archives:
+  - https://web.archive.org/web/20070728134131/http://bknight0.myweb.uga.edu/toki/text/allman.html#Midnight Rider
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Pije/Allman%20Midnight%20Rider.txt
+preprocessing: 'jan Pije li toki e ni: "[I don't understand what the songwriter was trying to convey in this line. Therefore, I have chosen not to translate it.]". mi lili e ni tawa "[...]". mi poki tu wan e toki. mi weka e toki Inli tan.'
+accessibility-notes: null
+notes: null
+---
+
+mi wile tawa tan ni: mi wile ala awen lon ma wan poka jan ike.  
+mi wile tawa.  
+mi jo e mani lili.  
+taso ona li ken ala jo e mi.  
+ona li ken ala jo e jan tawa pi tenpo pimeja.
+
+len ni li pi mi ala.  
+nasin li pini ala.  
+mi jo e mani lili.  
+taso ona li ken ala jo e mi.  
+ona li ken ala jo e jan tawa pi tenpo pimeja.
+
+[...]  
+tenpo kama lili la mi lon supa lape poka jan ante.  
+mi jo e mani lili.  
+taso ona li ken ala jo e mi.  
+ona li ken ala jo e jan tawa pi tenpo pimeja.

--- a/plaintext/2007/06/midnight-rider.md
+++ b/plaintext/2007/06/midnight-rider.md
@@ -18,7 +18,7 @@ sources:
 archives:
   - https://web.archive.org/web/20070728134131/http://bknight0.myweb.uga.edu/toki/text/allman.html#Midnight Rider
   - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Pije/Allman%20Midnight%20Rider.txt
-preprocessing: 'jan Pije li toki e ni: "[I don't understand what the songwriter was trying to convey in this line. Therefore, I have chosen not to translate it.]". mi lili e ni tawa "[...]". mi poki tu wan e toki. mi weka e toki Inli tan.'
+preprocessing: "jan Pije li toki e ni: '[I don't understand what the songwriter was trying to convey in this line. Therefore, I have chosen not to translate it.]'. mi lili e ni tawa '[...]'. mi poki tu wan e toki. mi weka e toki Inli tan."
 accessibility-notes: null
 notes: null
 ---

--- a/plaintext/2007/06/revival.md
+++ b/plaintext/2007/06/revival.md
@@ -1,0 +1,49 @@
+---
+title: Revival
+description: null
+authors:
+  - jan Pije
+proofreaders: null
+date: 2007-06-24
+date-precision: day # Archived on July 28th, Linked to in a June 24th archive which lacked the link on June 22th.
+tags: 
+  - lyrics
+original:
+  title: Revival (Love Is Everywhere)
+  authors:
+    - The Allman Brothers Band
+license: Public Domain # https://web.archive.org/web/20110809134608/http://bknight0.myweb.uga.edu/toki/copyright.html
+sources:
+  - https://web.archive.org/web/20070728134131/http://bknight0.myweb.uga.edu/toki/text/allman.html#Revival
+archives:
+  - https://web.archive.org/web/20070728134131/http://bknight0.myweb.uga.edu/toki/text/allman.html#Revival
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Pije/Allman%20Midnight%20Rider.txt
+preprocessing: 'mi poki tu wan e toki. mi weka e toki Inli tan'
+accessibility-notes: null
+notes: null
+---
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken kute e ona? olin li lon kon.  
+mi mute li pali e ijo sin.  
+sina sona ala sona e ni?: mi mute li pona.  
+jan ali li toki musi.  
+a! jan ala li wile utala.
+
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona?  
+olin li lon ali.  
+olin li lon ali.  
+olin li lon ali.
+
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.  
+jan o, sina ken ala ken pilin e ona? olin li lon ali.

--- a/plaintext/2009/07/ma-pi-soweli-nasa.md
+++ b/plaintext/2009/07/ma-pi-soweli-nasa.md
@@ -1,0 +1,65 @@
+---
+title: soweli pi nena kiwen
+description: null
+authors:
+  - jan Pije
+proofreaders: null
+date: 2009-07-21
+date-precision: day # mentioned on the yahoo mailing list
+tags: null
+original:
+  title: Where the Wild Things Are
+  authors:
+    - Maurice Sendak
+license: null
+sources:
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Pije/ma%20pi%20soweli%20nasa.txt
+archives: null
+preprocessing: 'mi weka e sitelen \" tan nimi ale tan ni: pilin mi la ona li lon ala lipu pi jan Pije li tan jan awen taso'
+accessibility-notes: null
+notes: lipu tan li weka. ken la ni li ante lili tan toki open pi jan Pije.
+---
+ma pi soweli nasa.  
+ni li tan jan Maurice-Sendak.
+
+tenpo pimeja wan la jan Max li jo e len soweli li pakala e ijo mute.  
+kin.  
+mama ona li toki e ni tawa jan Max: 'sina soweli nasa!'  
+jan Max: 'mi moku e sina!'  
+mama ona: 'o tawa tomo sina! sina ken ala jo e moku!'
+
+tenpo pimeja ni la kasi li suli lon tomo pi jan Max li suli li suli! palisa kasi li lon sewi. sinpin tomo li weka.
+
+telo suli li lon. jan Max li tawa kepeken tomo-tawa-telo.
+
+tenpo suli la jan Max li tawa lon telo. ona li kama tawa ma pi soweli nasa.
+
+ona li lon ma pi soweli nasa la soweli nasa li mu ike li jo e kiwen uta walo ike li jo e oko ike li jo e noka ike.
+
+jan Max li toki e ni: 'o pona!' ona li lukin wawa e oko jelo ali pi soweli nasa.
+
+soweli nasa li pilin e ni: jan Max li wawa li nasa mute.
+
+soweli nasa li wile e ni: jan Max li lawa e soweli nasa ali.
+
+jan Max li toki e ni: 'a! musi nasa o open!'
+
+jan Max li toki e ni: 'o pini! o tawa supa lape sina! sina ken ala jo e moku!' jan Max li lawa e soweli nasa ali.  
+taso ona li pilin ike. ona li wile olin.
+
+jan Max li pilin e kon pi moku pona tan ma weka.  
+ona li pini lawa e soweli nasa ali.
+
+soweli nasa li toki e ni: 'a! o weka ala! mi mute li moku e sina! mi mute li olin mute e sina!'
+
+jan Max li toki e ni: 'ala!'
+
+soweli nasa li mu ike li jo e kiwen uta walo ike li jo e oko ike li jo e noka ike.
+
+jan Max li tawa tomo-tawa-telo ona.  ona li toki e ni: 'mi tawa!'
+
+tenpo suli la jan Max li tawa lon telo.
+
+tenpo pimeja wan la ona li kama tawa tomo ona. moku li lon.
+
+ona li seli kin.

--- a/plaintext/2011/02/kala.md
+++ b/plaintext/2011/02/kala.md
@@ -11,7 +11,8 @@ original: null
 license: null
 sources:
   - https://olukin.blogspot.com/2011/03/kala.html
-archives: null
+archives:
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Ote%20Derivs/jan%20lawa%20Oliki%20Soweli%20Elepanto.txt
 preprocessing: null
 accessibility-notes: null
 notes: null

--- a/plaintext/2011/03/jan-lawa-oliki.md
+++ b/plaintext/2011/03/jan-lawa-oliki.md
@@ -14,7 +14,8 @@ original:
 license: null
 sources:
   - https://olukin.blogspot.com/2011/04/jan-lawa-oliki.html
-archives: null
+archives:
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Ote%20Derivs/jan%20lawa%20Oliki%20Soweli%20Elepanto.txt
 preprocessing: null
 accessibility-notes: null
 notes: null

--- a/plaintext/2011/04/kala-ma-li-lon-ala-tan-seme.md
+++ b/plaintext/2011/04/kala-ma-li-lon-ala-tan-seme.md
@@ -2,7 +2,7 @@
 title: kala ma li lon ala tan seme?
 description: null
 authors:
-  - anonymous
+  - jan Mika
 proofreaders: null
 date: 2011-04-01
 date-precision: day

--- a/plaintext/2011/04/kala-ma-li-lon-ala-tan-seme.md
+++ b/plaintext/2011/04/kala-ma-li-lon-ala-tan-seme.md
@@ -11,7 +11,8 @@ original: null
 license: null
 sources:
   - https://olukin.blogspot.com/2011/04/kala-ma-li-lon-ala-tan-seme.html
-archives: null
+archives:
+  - https://github.com/davidar/nltk-tp/blob/master/Corpus/Derivative%20Works%20of%20(C)/jan%20Ote%20Derivs/jan%20Mika%20-%20kala%20ma%20li%20lon%20ala%20tan%20seme.txt
 preprocessing: null
 accessibility-notes: null
 notes: null

--- a/plaintext/unknown-year/unknown-month/jan-lawa-lili.md
+++ b/plaintext/unknown-year/unknown-month/jan-lawa-lili.md
@@ -2,10 +2,10 @@
 title: jan lawa lili
 description: A translation of Antoine de Saint-Exupéry's The Little Prince
 authors:
-  - Micheal F.
+  - Michael F.
 proofreaders: null
-date: '2013-01-20'
-date-precision: day
+date: 2001-01-01
+date-precision: none
 original:
   title: The Little Prince
   authors:
@@ -18,7 +18,9 @@ license: CC BY-NC 4.0
 sources:
   - http://failbluedot.com/toki_pona/jan_lawa_lili/chap01
 archives:
+  - https://web.archive.org/web/20080719153012/http://anadder.com/toki_pona/jan_lawa_lili
   - https://web.archive.org/web/20151009153200/http://failbluedot.com/toki_pona/jan_lawa_lili/chap01
+  - https://github.com/davidar/nltk-tp/tree/master/Corpus/Derivative%20Works%20of%20(C)/Michael%20Freedman/LittlePrince
 preprocessing: null
 accessibility-notes: null
 notes: The older translation


### PR DESCRIPTION
I'm slowly adding texts from jan Mato's tokipona.net corpus (aka nltk-tp). You can track my progress on issue #133.
Only a small part is done, but I'm making a PR now so that there's not too many files to review all at once.

Note that the source corpus lacks metadata (beside author + approximate title) and the data is often subtly editorialised, so I've found & linked the original source (apart from for jan Pije's _ma pi soweli nasa_ (_Where the Wild Things Are_ translation) which I couldn't locate). I've tried my best to provide accurate dating (q difficult for most texts this old) with justifications added via comments. 

Changes in this PR:
- add source to README
- create 14 new files, namely 2002/10/jan-uluka-li-pilin-ike, 2002/10/sijelo-pi-nasin-pona, 2002/10/tenpo-suno-ni-iwa, 2002/10/tomo-palisa-pi-papeli, 2004/06/lipu-sewi, 2004/06/o-toki-pi-jan-sewi, 2004/06/son-23, 2005/09/toki-utala-Supaka, 2006/02/lipu-pi-jan-pona-sewi-matejo, 2007/06/blue-sky, 2007/06/melissa, 2007/06/midnight-rider, 2007/06/revival, and 2009/07/ma-pi-soweli-nasa
- move 2013/01/jan-lawa-lili to unknown-year/unknown-month/jan-lawa-lili, fix typo in author's name, add an archive from 2008, and reset date to unknown
- add extra (nltk-tp) archive to 2011/02/kala, 2011/03/jan-lawa-oliki, 2011/04/kala-ma-li-lon-ala-tan-seme, unknown-year/unknown-month/jan-lawa-lili
- add author to 2011/04/kala-ma-li-lon-ala-tan-seme
